### PR TITLE
Add delete league/team functionality

### DIFF
--- a/cmd/api/leagues.go
+++ b/cmd/api/leagues.go
@@ -14,10 +14,10 @@ func getLeagues(c *gin.Context) {
 	c.JSON(http.StatusOK, leagues)
 }
 
-func getLeague(c *gin.Context) {
+func getLeagueById(c *gin.Context) {
 	var league model.League
 	id := c.Param("leagueId")
-	db.Limit(1).Find(&league, "id = ?", id)
+	db.Limit(1).Preload("Teams").Find(&league, "id = ?", id)
 
 	if league.ID == nil {
 		c.Status(http.StatusNoContent)
@@ -30,6 +30,11 @@ func getLeague(c *gin.Context) {
 func createLeague(c *gin.Context) {
 	var league model.League
 	readBody(c, &league)
+
+	if league.Teams == nil {
+		league.Teams = []model.Team{}
+	}
+
 	db.Create(&league)
 
 	if league.ID == nil {
@@ -38,4 +43,10 @@ func createLeague(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusCreated, league)
+}
+
+func deleteLeagueById(c *gin.Context) {
+	id := c.Param("leagueId")
+	db.Select("Teams").Delete(&model.League{ID: &id})
+	c.Status(http.StatusNoContent)
 }

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -17,12 +17,14 @@ func main() {
 	leagues := r.Group("/leagues")
 	leagues.POST("/", createLeague)
 	leagues.GET("/", getLeagues)
-	leagues.GET("/:leagueId", getLeague)
+	leagues.GET("/:leagueId", getLeagueById)
+	leagues.DELETE("/:leagueId", deleteLeagueById)
 
 	teams := leagues.Group("/:leagueId/teams")
 	teams.POST("/", createTeam)
 	teams.GET("/", getTeamsByLeague)
-	teams.GET("/:teamId", getTeamInLeague)
+	teams.GET("/:teamId", getTeamById)
+	teams.DELETE("/:teamId", deleteTeamById)
 
 	r.Run()
 }

--- a/cmd/api/teams.go
+++ b/cmd/api/teams.go
@@ -8,13 +8,15 @@ import (
 )
 
 func getTeamsByLeague(c *gin.Context) {
+	id := c.Param("leagueId")
+
 	// TODO pagination
 	var teams []model.Team
-	db.Find(&teams)
+	db.Find(&teams, "league_id = ?", id)
 	c.JSON(http.StatusOK, teams)
 }
 
-func getTeamInLeague(c *gin.Context) {
+func getTeamById(c *gin.Context) {
 	var team model.Team
 	id := c.Param("teamId")
 	db.Limit(1).Find(&team, "id = ?", id)
@@ -38,4 +40,10 @@ func createTeam(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusCreated, team)
+}
+
+func deleteTeamById(c *gin.Context) {
+	id := c.Param("teamId")
+	db.Delete(&model.Team{}, "id = ?", id)
+	c.Status(http.StatusNoContent)
 }

--- a/model/league.go
+++ b/model/league.go
@@ -8,6 +8,7 @@ type League struct {
 	Abbr      *string   `json:"abbr" gorm:"not null"`
 	Sport     *string   `json:"sport" gorm:"not null"`
 	Level     *string   `json:"level" gorm:"not null"`
+	Teams     []Team    `json:"teams"`
 	CreatedAt time.Time `json:"createdAt" gorm:"autoCreateTime:nano"`
 	UpdatedAt time.Time `json:"updatedAt" gorm:"autoUpdateTime:nano"`
 }

--- a/model/team.go
+++ b/model/team.go
@@ -10,7 +10,7 @@ type Team struct {
 	Abbr       *string   `json:"abbr" gorm:"not null"`
 	Conference *string   `json:"conference"`
 	Division   *string   `json:"division"`
-	LeagueID   *string   `json:"leagueId" gorm:"type:uuid;foreignKey"`
+	LeagueID   *string   `json:"leagueId" gorm:"type:uuid"`
 	CreatedAt  time.Time `json:"createdAt" gorm:"autoCreateTime:nano"`
 	UpdatedAt  time.Time `json:"updatedAt" gorm:"autoUpdateTime:nano"`
 }


### PR DESCRIPTION
The neat discovery here (in addition to using deletions with Gorm) was baking Teams into the League model without a strict foreign key requirement on the database side.

Not exactly sure where I'll land on this, but for now, the delete operations work as expected: an individual Team can be deleted from a League, and deleting a League also deletes all its associated Teams.

The next step will be to start creating seasons, matches, etc.